### PR TITLE
Prevents amplitudes from being mapped below 0.0

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -41,7 +41,11 @@ class FFTModel: ObservableObject {
             // add the amplitude to our array (further scaling array to look good in visualizer)
             DispatchQueue.main.async {
                 if i / 2 < self.amplitudes.count {
-                    self.amplitudes[i / 2] = self.map(n: scaledAmplitude, start1: 0.3, stop1: 0.9, start2: 0.0, stop2: 1.0)
+                    var mappedAmplitude = self.map(n: scaledAmplitude, start1: 0.3, stop1: 0.9, start2: 0.0, stop2: 1.0)
+                    if mappedAmplitude < 0.0 {
+                        mappedAmplitude = 0.0
+                    }
+                    self.amplitudes[i / 2] = mappedAmplitude
                 }
             }
         }


### PR DESCRIPTION
Issue: The map function is producing negative values, which is causing the FFTView "caps" to be offset below the view. 
Fix: Set all negative values to 0.0