### PR TITLE
FFTView: Remove Magic Numbers (also fixed the incorrect FFT_SIZE)

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -6,7 +6,7 @@ import SwiftUI
 class FFTModel: ObservableObject {
     @Published var amplitudes: [Double?] = Array(repeating: nil, count: 50)
     var nodeTap: FFTTap!
-    private var FFT_SIZE = 512
+    private var FFT_SIZE = 2048
     var node: Node?
 
     func updateNode(_ node: Node) {
@@ -40,11 +40,8 @@ class FFTModel: ObservableObject {
                 let normalizedBinMagnitude = 2.0 * sqrt(real * real + imaginary * imaginary) / Float(FFT_SIZE)
                 let amplitude = Double(20.0 * log10(normalizedBinMagnitude))
 
-                // scale the resulting data
-                let scaledAmplitude = (amplitude + 250) / 229.80
-
-                // further scaling array to look good in visualizer
-                var mappedAmplitude = map(n: scaledAmplitude, start1: 0.7, stop1: 1.45, start2: 0.0, stop2: 1.0)
+                // map amplitude array to visualizer
+                var mappedAmplitude = map(n: amplitude, start1: -150, stop1: -10.0, start2: 0.0, stop2: 1.0)
                 if mappedAmplitude > 1.0 {
                     mappedAmplitude = 1.0
                 }


### PR DESCRIPTION
Now that we are getting the appropriate output from FFTTap, we can remove the magic numbers from FFTView and adjust the mapping to the new FFTTap output data.

We should think about how we might want to add minimum and maximum adjustment factors to FFTView which would adjust the -150 and -10.0 values in the map function. This would compress or expand the range of the amplitude bars - I think developers will want that control. I picked good default values for now.

I'm thinking something like minFactor will adjust the current -150 value within a range of -200 to -100 and the max factor will adjust the -10.0 within the range of -50 to -0.