### PR TITLE
FFTView: Allow compression and expansion of amplitude bars

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -8,6 +8,8 @@ class FFTModel: ObservableObject {
     var nodeTap: FFTTap!
     private var FFT_SIZE = 2048
     var node: Node?
+    var maxAmplitude: Double = -10.0
+    var minAmplitude: Double = -150.0
 
     func updateNode(_ node: Node) {
         if node !== self.node {
@@ -41,7 +43,7 @@ class FFTModel: ObservableObject {
                 let amplitude = Double(20.0 * log10(normalizedBinMagnitude))
 
                 // map amplitude array to visualizer
-                var mappedAmplitude = map(n: amplitude, start1: -150, stop1: -10.0, start2: 0.0, stop2: 1.0)
+                var mappedAmplitude = map(n: amplitude, start1: minAmplitude, stop1: maxAmplitude, start2: 0.0, stop2: 1.0)
                 if mappedAmplitude > 1.0 {
                     mappedAmplitude = 1.0
                 }
@@ -70,18 +72,32 @@ public struct FFTView: View {
     private var paddingFraction: CGFloat
     private var includeCaps: Bool
     private var node: Node
+    private var minAmplitude: Double
+    private var maxAmplitude: Double
 
     public init(_ node: Node,
                 linearGradient: LinearGradient = LinearGradient(gradient: Gradient(colors: [.red, .yellow, .green]),
                                                                 startPoint: .top,
                                                                 endPoint: .center),
                 paddingFraction: CGFloat = 0.2,
-                includeCaps: Bool = true)
+                includeCaps: Bool = true,
+                maxAmplitude: Double = -10.0,
+                minAmplitude: Double = -150.0)
     {
         self.node = node
         self.linearGradient = linearGradient
         self.paddingFraction = paddingFraction
         self.includeCaps = includeCaps
+        self.maxAmplitude = maxAmplitude
+        self.minAmplitude = minAmplitude
+
+        if maxAmplitude < minAmplitude {
+            fatalError("Maximum amplitude cannot be less than minimum amplitude")
+        }
+        if (minAmplitude > 0.0 || maxAmplitude > 0.0){
+            fatalError("Amplitude values must be less than zero")
+        }
+        
     }
 
     public var body: some View {
@@ -96,6 +112,8 @@ public struct FFTView: View {
             }
         }.onAppear {
             fft.updateNode(node)
+            fft.maxAmplitude = self.maxAmplitude
+            fft.minAmplitude = self.minAmplitude
         }
         .drawingGroup() // Metal powered rendering
         .background(Color.black)

--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -94,10 +94,9 @@ public struct FFTView: View {
         if maxAmplitude < minAmplitude {
             fatalError("Maximum amplitude cannot be less than minimum amplitude")
         }
-        if (minAmplitude > 0.0 || maxAmplitude > 0.0){
+        if minAmplitude > 0.0 || maxAmplitude > 0.0 {
             fatalError("Amplitude values must be less than zero")
         }
-        
     }
 
     public var body: some View {


### PR DESCRIPTION
Added min and max amplitudes to adjust the range of the amplitude bars.

We may want to add optional amplitude labels to the side of the visualizer at some point to help the developer / user understand their levels.