### PR TITLE
FFTView: added ability to change the number of amplitude bars

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -8,6 +8,7 @@ class FFTModel: ObservableObject {
     var nodeTap: FFTTap!
     private var FFT_SIZE = 2048
     var node: Node?
+    var numberOfBars: Int = 50
 
     func updateNode(_ node: Node) {
         if node !== self.node {
@@ -32,7 +33,7 @@ class FFTModel: ObservableObject {
 
         // loop by two through all the fft data
         for i in stride(from: 0, to: FFT_SIZE - 1, by: 2) {
-            if i / 2 < amplitudes.count {
+            if i / 2 < numberOfBars {
                 // get the real and imaginary parts of the complex number
                 let real = fftData[i]
                 let imaginary = fftData[i + 1]
@@ -70,23 +71,26 @@ public struct FFTView: View {
     private var paddingFraction: CGFloat
     private var includeCaps: Bool
     private var node: Node
+    private var numberOfBars: Int
 
     public init(_ node: Node,
                 linearGradient: LinearGradient = LinearGradient(gradient: Gradient(colors: [.red, .yellow, .green]),
                                                                 startPoint: .top,
                                                                 endPoint: .center),
                 paddingFraction: CGFloat = 0.2,
-                includeCaps: Bool = true)
+                includeCaps: Bool = true,
+                numberOfBars: Int = 50)
     {
         self.node = node
         self.linearGradient = linearGradient
         self.paddingFraction = paddingFraction
         self.includeCaps = includeCaps
+        self.numberOfBars = numberOfBars
     }
 
     public var body: some View {
         HStack(spacing: 0.0) {
-            ForEach(0 ..< fft.amplitudes.count) { number in
+            ForEach(fft.amplitudes.indices, id: \.self) { number in
                 if let amplitude = fft.amplitudes[number] {
                     AmplitudeBar(amplitude: amplitude,
                                  linearGradient: linearGradient,
@@ -96,6 +100,7 @@ public struct FFTView: View {
             }
         }.onAppear {
             fft.updateNode(node)
+            fft.numberOfBars = self.numberOfBars
         }
         .drawingGroup() // Metal powered rendering
         .background(Color.black)


### PR DESCRIPTION
This allows the user to change the number of amplitude bars.

IMPORTANT NOTE: the dev could choose too many bars and the application will crash because they are too small to actually be written to the screen - or at least that's what the error looks like to me. I haven't thought of how to handle that. I'd like to have a useful fatal error to catch it and inform the dev.

Additionally, it's dawned on me that we are only showing the lowest (albiet most exciting) part of the frequency spectrum in the visualizer with 50 bars chosen. I wonder if there's a way to strategically combine bins to show more of the frequency spectrum without having too many amplitude bars..