### PR TITLE
Impliment updateUIView for KeyboardWidget

### DIFF
--- a/Sources/AudioKitUI/Controls/KeyboardWidget.swift
+++ b/Sources/AudioKitUI/Controls/KeyboardWidget.swift
@@ -3,7 +3,6 @@
 import AudioKit
 import SwiftUI
 
-/// SwiftUI View - Wraps a KeyboardView
 public struct KeyboardWidget: ViewRepresentable {
     var firstOctave: Int
     var octaveCount: Int

--- a/Sources/AudioKitUI/Controls/KeyboardWidget.swift
+++ b/Sources/AudioKitUI/Controls/KeyboardWidget.swift
@@ -3,16 +3,6 @@
 import AudioKit
 import SwiftUI
 
-/// Settings class for the KeyboardWidget - Publishes to KeyboardView
-public class KeyboardWidgetSettings: ObservableObject {
-    /// Octave Count for the wrapped KeyboardView
-    @Published public var octaveCount: Int = 2
-    /// First Octave for the wrapped KeyboardView
-    @Published public var firstOctave: Int = 0
-    /// Polyphonic Mode toggle for the wrapped KeyboardView
-    @Published public var polyphonicMode: Bool = false
-    public init() {}
-}
 /// SwiftUI View - Wraps a KeyboardView
 public struct KeyboardWidget: ViewRepresentable {
     var firstOctave: Int
@@ -35,7 +25,7 @@ public struct KeyboardWidget: ViewRepresentable {
         nsView.firstOctave = firstOctave
         nsView.octaveCount = octaveCount
         nsView.polyphonicMode = polyphonicMode
-        view.setNeedsDisplay()
+        nsView.setNeedsDisplay()
     }
     #else
     public func makeUIView(context: Context) -> KeyboardView {

--- a/Sources/AudioKitUI/Controls/KeyboardWidget.swift
+++ b/Sources/AudioKitUI/Controls/KeyboardWidget.swift
@@ -1,10 +1,23 @@
+// Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
+
 import AudioKit
 import SwiftUI
 
+/// Settings class for the KeyboardWidget - Publishes to KeyboardView
+public class KeyboardWidgetSettings: ObservableObject {
+    /// Octave Count for the wrapped KeyboardView
+    @Published public var octaveCount: Int = 2
+    /// First Octave for the wrapped KeyboardView
+    @Published public var firstOctave: Int = 0
+    /// Polyphonic Mode toggle for the wrapped KeyboardView
+    @Published public var polyphonicMode: Bool = false
+    public init() {}
+}
+/// SwiftUI View - Wraps a KeyboardView
 public struct KeyboardWidget: ViewRepresentable {
-
-    public var firstOctave = 2
-    public var octaveCount = 2
+    var firstOctave: Int
+    var octaveCount: Int
+    var polyphonicMode: Int
 
     public typealias UIViewType = KeyboardView
     public var delegate: KeyboardDelegate?
@@ -15,24 +28,36 @@ public struct KeyboardWidget: ViewRepresentable {
         view.delegate = delegate
         view.firstOctave = firstOctave
         view.octaveCount = octaveCount
+        view.polyphonicMode = polyphonicMode
         return view
     }
-    public func updateNSView(_ nsView: KeyboardView, context: Context) {}
+    public func updateNSView(_ nsView: KeyboardView, context: Context) {
+        nsView.firstOctave = firstOctave
+        nsView.octaveCount = octaveCount
+        nsView.polyphonicMode = polyphonicMode
+        view.setNeedsDisplay()
+    }
     #else
     public func makeUIView(context: Context) -> KeyboardView {
-
         let view = KeyboardView()
         view.delegate = delegate
         view.firstOctave = firstOctave
         view.octaveCount = octaveCount
+        view.polyphonicMode = polyphonicMode
         return view
     }
-    public func updateUIView(_ uiView: KeyboardView, context: Context) {}
+    public func updateUIView(_ uiView: KeyboardView, context: Context) {
+        uiView.firstOctave = firstOctave
+        uiView.octaveCount = octaveCount
+        uiView.polyphonicMode = polyphonicMode
+        uiView.setNeedsDisplay()
+    }
     #endif
 
-    public init(delegate: KeyboardDelegate? = nil, firstOctave: Int = 2, octaveCount: Int = 2) {
+    public init(delegate: KeyboardDelegate? = nil, firstOctave: Int, octaveCount: Int) {
         self.delegate = delegate
         self.firstOctave = firstOctave
         self.octaveCount = octaveCount
+        self.polyphonicMode = polyphonicMode
     }
 }

--- a/Sources/AudioKitUI/Controls/KeyboardWidget.swift
+++ b/Sources/AudioKitUI/Controls/KeyboardWidget.swift
@@ -25,7 +25,8 @@ public struct KeyboardWidget: ViewRepresentable {
         nsView.firstOctave = firstOctave
         nsView.octaveCount = octaveCount
         nsView.polyphonicMode = polyphonicMode
-        nsView.setNeedsDisplay()
+        nsView.needsDisplay = true
+        nsView.displayIfNeeded()
     }
     #else
     public func makeUIView(context: Context) -> KeyboardView {

--- a/Sources/AudioKitUI/Controls/KeyboardWidget.swift
+++ b/Sources/AudioKitUI/Controls/KeyboardWidget.swift
@@ -17,7 +17,7 @@ public class KeyboardWidgetSettings: ObservableObject {
 public struct KeyboardWidget: ViewRepresentable {
     var firstOctave: Int
     var octaveCount: Int
-    var polyphonicMode: Int
+    var polyphonicMode: Bool
 
     public typealias UIViewType = KeyboardView
     public var delegate: KeyboardDelegate?
@@ -54,7 +54,7 @@ public struct KeyboardWidget: ViewRepresentable {
     }
     #endif
 
-    public init(delegate: KeyboardDelegate? = nil, firstOctave: Int, octaveCount: Int) {
+    public init(delegate: KeyboardDelegate? = nil, firstOctave: Int, octaveCount: Int, polyphonicMode: Bool) {
         self.delegate = delegate
         self.firstOctave = firstOctave
         self.octaveCount = octaveCount


### PR DESCRIPTION
These changes allow the wrapped KeyboardView to update certain properties through SwiftUI when needed. 

This will partially help with AudioKit/Cookbook#1, but I also need to update the Cookbook examples using `KeyboardWidget()`.

Edit: The `KeyboardWidgetSettings` class was not needed to publish changes when the view is updated. I just realized SwiftUI does that automatically when a `@State var` is passed into the `KeyboardWidget` class.