### PR TITLE
Simplify and Fix FFTView

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -36,12 +36,8 @@ class FFTModel: ObservableObject {
         // loop by two through all the fft data
         for i in stride(from: 0, to: FFT_SIZE - 1, by: 2) {
             if i / 2 < numberOfBars {
-                // get the real and imaginary parts of the complex number
-                let real = fftData[i]
-                let imaginary = fftData[i + 1]
-
-                let normalizedBinMagnitude = 2.0 * sqrt(real * real + imaginary * imaginary) / Float(FFT_SIZE)
-                let amplitude = Double(20.0 * log10(normalizedBinMagnitude))
+                let binMagnitude = fftData[i]
+                let amplitude = Double(10.0 * log10(binMagnitude))
 
                 // map amplitude array to visualizer
                 var mappedAmplitude = map(n: amplitude,


### PR DESCRIPTION
The `fftData` in `FFTView` seems to have been interpreted as an interleaved complex array of numbers when it was really the squared addition of a split complex number as shown below:

<img alt="vDSP_zvmags" src="https://docs-assets.developer.apple.com/published/097ccd4f03/vdsp_104_2x_c591ed49-3779-4fe9-98cf-28ae8e14b187.png" width="400" height="50">

These code changes correct for that as mentioned in AudioKit/AudioKit#2578.