### PR TITLE
Improve FFT view by preserving all frequencies by averaging based on number of bars displayed

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -48,8 +48,9 @@ class FFTModel: ObservableObject {
 
         for (index, decibel) in decibels.enumerated() {
             let bar = index / binsPerBar
+            let averagedDecibel = (decibel.isNaN ? 0.0 : decibel) * (1 / Float(binsPerBar))
 
-            tempAmplitudes[bar] += decibel * (1 / Float(binsPerBar))
+            tempAmplitudes[bar] += averagedDecibel
         }        
 
         // swap the amplitude array

--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -4,13 +4,13 @@ import AudioKit
 import SwiftUI
 
 class FFTModel: ObservableObject {
-    @Published var amplitudes: [Double?] = Array(repeating: nil, count: 50)
+    @Published var amplitudes: [Float?] = Array(repeating: nil, count: 50)
     var nodeTap: FFTTap!
     private var FFT_SIZE = 2048
     var node: Node?
     var numberOfBars: Int = 50
-    var maxAmplitude: Double = -10.0
-    var minAmplitude: Double = -150.0
+    var maxAmplitude: Float = -10.0
+    var minAmplitude: Float = -150.0
 
     func updateNode(_ node: Node) {
         if node !== self.node {
@@ -74,8 +74,8 @@ public struct FFTView: View {
     private var includeCaps: Bool
     private var node: Node
     private var numberOfBars: Int
-    private var minAmplitude: Double
-    private var maxAmplitude: Double
+    private var minAmplitude: Float
+    private var maxAmplitude: Float
 
     public init(_ node: Node,
                 linearGradient: LinearGradient = LinearGradient(gradient: Gradient(colors: [.red, .yellow, .green]),
@@ -84,8 +84,8 @@ public struct FFTView: View {
                 paddingFraction: CGFloat = 0.2,
                 includeCaps: Bool = true,
                 numberOfBars: Int = 50,
-                maxAmplitude: Double = -10.0,
-                minAmplitude: Double = -150.0)
+                maxAmplitude: Float = -10.0,
+                minAmplitude: Float = -150.0)
     {
         self.node = node
         self.linearGradient = linearGradient
@@ -131,7 +131,7 @@ struct FFTView_Previews: PreviewProvider {
 }
 
 struct AmplitudeBar: View {
-    var amplitude: Double
+    var amplitude: Float
     var linearGradient: LinearGradient
     var paddingFraction: CGFloat = 0.2
     var includeCaps: Bool = true

--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -35,7 +35,7 @@ class FFTModel: ObservableObject {
                     self.updateAmplitudes(fftData)
                 }
             }
-            nodeTap.isNormalized = false
+            nodeTap.isNormalized = true
             nodeTap.start()
         }
     }
@@ -50,7 +50,7 @@ class FFTModel: ObservableObject {
         var decibelNormalizationOffset = Float(-minAmplitude / (maxAmplitude - minAmplitude))
 
         var decibels = [Float](repeating: 0, count: fftData.count)
-        vDSP_vdbcon(fftData, 1, &one, &decibels, 1, vDSP_Length(fftData.count), 0)
+        vDSP_vdbcon(fftData, 1, &one, &decibels, 1, vDSP_Length(fftData.count), 1)
         vDSP_vsmsa(
             decibels, 1,
             &decibelNormalizationFactor,


### PR DESCRIPTION
The current FFTView code throws away data that doesn't fit into the number of bars displayed in the UI. This means that higher frequencies won't be displayed.

This fixes FFTView by preserving data from those higher frequencies, and aggregates the frequencies into the number of bars to be displayed by averaging them. I have no idea if averaging is the best way to do this aggregation.

I also pulled out some of the math from the loop into functions provided by Accelerate. I didn't benchmark, so perhaps this is slower, but it looks fancier 😀 .

You can see the difference in how higher frequencies display in these screenshots. The first is the original code... you'll notice that the FFTView shows nothing. The second is running this branch. (Btw, I had to tweak the Oscillator recipe to allow a higher max frequency.)

## Before
<img width="346" alt="Screen Shot 2021-08-15 at 9 33 08 PM" src="https://user-images.githubusercontent.com/341478/129500572-2ca8e044-1d55-4c25-8671-e2765b1d9697.png">


## After
<img width="341" alt="Screen Shot 2021-08-15 at 9 32 21 PM" src="https://user-images.githubusercontent.com/341478/129500579-5b0ec6eb-f7e1-461e-99be-861811ae191a.png">
