### PR TITLE
FFTView add ability to set bin count and bar count

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "AudioKitUI",
     platforms: [ .macOS(.v11), .iOS(.v14)],
     products: [.library(name: "AudioKitUI", targets: ["AudioKitUI"])],
-    dependencies: [.package(url: "https://github.com/AudioKit/AudioKit.git", from: "5.2.0")],
+    dependencies: [.package(url: "https://github.com/AudioKit/AudioKit.git", from: "5.2.1")],
     targets: [
         .target(name: "AudioKitUI", dependencies: ["AudioKit"]),
         .testTarget(name: "AudioKitUITests", dependencies: ["AudioKitUI"]),

--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -1,21 +1,22 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
 
+import Accelerate
 import AudioKit
 import SwiftUI
 
 class FFTModel: ObservableObject {
-    @Published var amplitudes: [Double?] = Array(repeating: nil, count: 50)
+    @Published var amplitudes: [Float?] = Array(repeating: nil, count: 50)
     var nodeTap: FFTTap!
-    private var FFT_SIZE = 2048
     var node: Node?
     var numberOfBars: Int = 50
-    var maxAmplitude: Double = -10.0
-    var minAmplitude: Double = -150.0
+    var maxAmplitude: Float = 0.0
+    var minAmplitude: Float = -70.0
+    var referenceValueForFFT: Float = 12.0
 
-    func updateNode(_ node: Node) {
+    func updateNode(_ node: Node, fftValidBinCount: FFTValidBinCount? = nil) {
         if node !== self.node {
             self.node = node
-            nodeTap = FFTTap(node) { fftData in
+            nodeTap = FFTTap(node, fftValidBinCount: fftValidBinCount) { fftData in
                 DispatchQueue.main.async {
                     self.updateAmplitudes(fftData)
                 }
@@ -31,43 +32,28 @@ class FFTModel: ObservableObject {
             if fftData[index].isNaN { fftData[index] = 0.0 }
         }
 
-        var tempAmplitudes: [Double] = []
+        var one = Float(1.0)
+        var zero = Float(0.0)
+        var decibelNormalizationFactor = Float(1.0 / (maxAmplitude - minAmplitude))
+        var decibelNormalizationOffset = Float(-minAmplitude / (maxAmplitude - minAmplitude))
 
-        // loop by two through all the fft data
-        for i in stride(from: 0, to: FFT_SIZE - 1, by: 2) {
-            if i / 2 < numberOfBars {
-                // get the real and imaginary parts of the complex number
-                let real = fftData[i]
-                let imaginary = fftData[i + 1]
+        var decibels = [Float](repeating: 0, count: fftData.count)
+        vDSP_vdbcon(fftData, 1, &referenceValueForFFT, &decibels, 1, vDSP_Length(fftData.count), 0)
 
-                let normalizedBinMagnitude = 2.0 * sqrt(real * real + imaginary * imaginary) / Float(FFT_SIZE)
-                let amplitude = Double(20.0 * log10(normalizedBinMagnitude))
+        vDSP_vsmsa(decibels,
+                   1,
+                   &decibelNormalizationFactor,
+                   &decibelNormalizationOffset,
+                   &decibels,
+                   1,
+                   vDSP_Length(decibels.count))
 
-                // map amplitude array to visualizer
-                var mappedAmplitude = map(n: amplitude,
-                                          start1: minAmplitude,
-                                          stop1: maxAmplitude,
-                                          start2: 0.0,
-                                          stop2: 1.0)
-                if mappedAmplitude > 1.0 {
-                    mappedAmplitude = 1.0
-                }
-                if mappedAmplitude < 0.0 {
-                    mappedAmplitude = 0.0
-                }
+        vDSP_vclip(decibels, 1, &zero, &one, &decibels, 1, vDSP_Length(decibels.count))
 
-                tempAmplitudes.append(mappedAmplitude)
-            }
-        }
         // swap the amplitude array
         DispatchQueue.main.async {
-            self.amplitudes = tempAmplitudes
+            self.amplitudes = decibels
         }
-    }
-
-    /// simple mapping function to scale a value to a different range
-    func map(n: Double, start1: Double, stop1: Double, start2: Double, stop2: Double) -> Double {
-        return ((n - start1) / (stop1 - start1)) * (stop2 - start2) + start2
     }
 }
 
@@ -77,9 +63,12 @@ public struct FFTView: View {
     private var paddingFraction: CGFloat
     private var includeCaps: Bool
     private var node: Node
-    private var numberOfBars: Int
-    private var minAmplitude: Double
-    private var maxAmplitude: Double
+    private var barCount: Int
+    private var fftValidBinCount: FFTValidBinCount?
+    private var minAmplitude: Float
+    private var maxAmplitude: Float
+    private let defaultBarCount: Int = 64
+    private let maxBarCount: Int = 128
 
     public init(_ node: Node,
                 linearGradient: LinearGradient = LinearGradient(gradient: Gradient(colors: [.red, .yellow, .green]),
@@ -87,17 +76,18 @@ public struct FFTView: View {
                                                                 endPoint: .center),
                 paddingFraction: CGFloat = 0.2,
                 includeCaps: Bool = true,
-                numberOfBars: Int = 50,
-                maxAmplitude: Double = -10.0,
-                minAmplitude: Double = -150.0)
+                validBinCount: FFTValidBinCount? = nil,
+                barCount: Int? = nil,
+                maxAmplitude: Float = -10.0,
+                minAmplitude: Float = -150.0)
     {
         self.node = node
         self.linearGradient = linearGradient
         self.paddingFraction = paddingFraction
         self.includeCaps = includeCaps
-        self.numberOfBars = numberOfBars
         self.maxAmplitude = maxAmplitude
         self.minAmplitude = minAmplitude
+        self.fftValidBinCount = validBinCount
 
         if maxAmplitude < minAmplitude {
             fatalError("Maximum amplitude cannot be less than minimum amplitude")
@@ -105,23 +95,43 @@ public struct FFTView: View {
         if minAmplitude > 0.0 || maxAmplitude > 0.0 {
             fatalError("Amplitude values must be less than zero")
         }
+
+        if let requestedBarCount = barCount {
+            self.barCount = requestedBarCount
+        } else {
+            if let fftBinCount = fftValidBinCount {
+                if Int(fftBinCount.rawValue) > maxBarCount - 1 {
+                    self.barCount = maxBarCount
+                } else {
+                    self.barCount = Int(fftBinCount.rawValue)
+                }
+            } else {
+                self.barCount = defaultBarCount
+            }
+        }
     }
 
     public var body: some View {
         HStack(spacing: 0.0) {
-            ForEach(fft.amplitudes.indices, id: \.self) { number in
-                if let amplitude = fft.amplitudes[number] {
-                    AmplitudeBar(amplitude: amplitude,
+            ForEach(0 ..< barCount) {
+                if $0 < fft.amplitudes.count {
+                    if let amplitude = fft.amplitudes[$0] {
+                        AmplitudeBar(amplitude: amplitude,
+                                     linearGradient: linearGradient,
+                                     paddingFraction: paddingFraction,
+                                     includeCaps: includeCaps)
+                    }
+                } else {
+                    AmplitudeBar(amplitude: 0.0,
                                  linearGradient: linearGradient,
                                  paddingFraction: paddingFraction,
                                  includeCaps: includeCaps)
                 }
             }
         }.onAppear {
-            fft.updateNode(node)
-            fft.numberOfBars = numberOfBars
-            fft.maxAmplitude = maxAmplitude
-            fft.minAmplitude = minAmplitude
+            fft.updateNode(node, fftValidBinCount: self.fftValidBinCount)
+            fft.maxAmplitude = self.maxAmplitude
+            fft.minAmplitude = self.minAmplitude
         }
         .drawingGroup() // Metal powered rendering
         .background(Color.black)
@@ -135,7 +145,7 @@ struct FFTView_Previews: PreviewProvider {
 }
 
 struct AmplitudeBar: View {
-    var amplitude: Double
+    var amplitude: Float
     var linearGradient: LinearGradient
     var paddingFraction: CGFloat = 0.2
     var includeCaps: Bool = true


### PR DESCRIPTION
This PR is dependent on the merge of this: https://github.com/AudioKit/AudioKit/pull/2581

Added ability to set the FFTTap bin count to any valid 2^n bin count

Changed calculation and scale for amplitude. Mostly follows the calculation brought forth by Alex Burgel in this PR: https://github.com/AudioKit/AudioKitUI/pull/25

Minor notes:
If you set a bin count, it will attempt to set the bar count to the same number (unless you exceed the maximum bar count allowed or you manually set the bar count)

If the bar count exceeds the bin count, it will still display a bar (at zero)