### PR TITLE
KnobView - Out of range values 

### DIFF
--- a/Sources/AudioKitUI/Controls/KnobView.swift
+++ b/Sources/AudioKitUI/Controls/KnobView.swift
@@ -43,8 +43,8 @@ public struct Knob: View {
                 }
                 var change = Float((dragPoint.location.x - lastLocation.x) * KnobDefaults.knobDragSensitivity)
                 change -= Float((dragPoint.location.y - lastLocation.y) * KnobDefaults.knobDragSensitivity)
-                value = value +  change * ((range.upperBound - range.lowerBound) + range.lowerBound)
-                value = min(range.upperBound, max(range.lowerBound, value))
+                let tempValue = value +  change * ((range.upperBound - range.lowerBound) + range.lowerBound)
+                value = min(range.upperBound, max(range.lowerBound, tempValue))
                 lastLocation = dragPoint.location
                 displayString = String(format: "%0.4f", value)
             }


### PR DESCRIPTION
When changing values of the Knob quickly the value goes beyond the min or max range before snapping to the min/max value. Setting a tempValue avoids setting "value" to an out of range value before using min/max in the next line.