### PR TITLE
Update FFTView.swift backgroundColor to change the view's secondary color

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -117,7 +117,8 @@ public struct FFTView: View {
                     AmplitudeBar(amplitude: amplitude,
                                  linearGradient: linearGradient,
                                  paddingFraction: paddingFraction,
-                                 includeCaps: includeCaps)
+                                 includeCaps: includeCaps,
+                                 backgroundColor: backgroundColor)
                 }
             }
         }.onAppear {
@@ -142,6 +143,7 @@ struct AmplitudeBar: View {
     var linearGradient: LinearGradient
     var paddingFraction: CGFloat = 0.2
     var includeCaps: Bool = true
+    var backgroundColor: Color = Color.black
 
     var body: some View {
         GeometryReader { geometry in
@@ -152,7 +154,7 @@ struct AmplitudeBar: View {
 
                 // Dynamic black mask padded from bottom in relation to the amplitude
                 Rectangle()
-                    .fill(Color.black)
+                    .fill(backgroundColor)
                     .mask(Rectangle().padding(.bottom, geometry.size.height * CGFloat(amplitude)))
                     .animation(.easeOut(duration: 0.15))
 
@@ -162,7 +164,7 @@ struct AmplitudeBar: View {
                 }
             }
             .padding(geometry.size.width * paddingFraction / 2)
-            .border(Color.black, width: geometry.size.width * paddingFraction / 2)
+            .border(backgroundColor, width: geometry.size.width * paddingFraction / 2)
         }
     }
 


### PR DESCRIPTION
This change allows backgroundColor to change the entire view's secondary color. Use case would be if you want a white FFTView with only the bars colored, you could init the FFTView like this:

`FFTView(conductor.reverb, backgroundColor: Color.white)`

(I'm submitting this to the main branch because it's the one that uses backgroundColor from the previous PR)

Thanks,
Nick