### PR TITLE
Updated NodeOutputView Background Color

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FragmentBuilder.swift
+++ b/Sources/AudioKitUI/Visualizations/FragmentBuilder.swift
@@ -24,11 +24,13 @@ public class FragmentBuilder {
     var isFFT: Bool = false
 
     init(foregroundColor: CGColor = Color.white.cg,
+         backgroundColor: CGColor = Color.clear.cg,
          isCentered: Bool = true,
          isFilled: Bool = true,
          isFFT: Bool = false)
     {
         self.foregroundColor = foregroundColor
+        self.backgroundColor = backgroundColor
         self.isCentered = isCentered
         self.isFilled = isFilled
         self.isFFT = isFFT

--- a/Sources/AudioKitUI/Visualizations/NodeOutputView.swift
+++ b/Sources/AudioKitUI/Visualizations/NodeOutputView.swift
@@ -10,7 +10,10 @@ public struct NodeOutputView: ViewRepresentable {
     private var metalFragment: FragmentBuilder
 
     public init(_ node: Node, color: Color = .gray, backgroundColor: Color = .clear, bufferSize: Int = 1024) {
-        metalFragment = FragmentBuilder(foregroundColor: color.cg, backgroundColor: backgroundColor.cg, isCentered: true, isFilled: false)
+        metalFragment = FragmentBuilder(foregroundColor: color.cg,
+                                        backgroundColor: backgroundColor.cg,
+                                        isCentered: true,
+                                        isFilled: false)
         nodeTap = RawDataTap(node, bufferSize: UInt32(bufferSize))
     }
 

--- a/Sources/AudioKitUI/Visualizations/NodeOutputView.swift
+++ b/Sources/AudioKitUI/Visualizations/NodeOutputView.swift
@@ -9,9 +9,8 @@ public struct NodeOutputView: ViewRepresentable {
     private var nodeTap: RawDataTap
     private var metalFragment: FragmentBuilder
 
-    public init(_ node: Node, color: Color = .gray, bufferSize: Int = 1024) {
-
-        metalFragment = FragmentBuilder(foregroundColor: color.cg, isCentered: true, isFilled: false)
+    public init(_ node: Node, color: Color = .gray, backgroundColor: Color = .clear, bufferSize: Int = 1024) {
+        metalFragment = FragmentBuilder(foregroundColor: color.cg, backgroundColor: backgroundColor.cg, isCentered: true, isFilled: false)
         nodeTap = RawDataTap(node, bufferSize: UInt32(bufferSize))
     }
 


### PR DESCRIPTION
This update gives access to the backgroundColor variable of NodeOutputView. Usage would be to have a colored waveform over a background that matches the user's UI color scheme: 

`NodeOutputView(conductor.osc, color: .purple, backgroundColor: .white)` 

Thanks,
Nick