### PR TITLE
Create MIDITrackViewModel

### DIFF
--- a/Sources/AudioKitUI/Controls/MIDITrackView.swift
+++ b/Sources/AudioKitUI/Controls/MIDITrackView.swift
@@ -46,7 +46,7 @@ struct NotesModel: ViewRepresentable {
         if let fileURL = fileURL {
             let noteMap = MIDIFileTrackNoteMap(midiFile: MIDIFile(url: fileURL), trackNumber: trackNumber)
             let length = CGFloat(noteMap.endOfTrack) * noteZoom
-            let view = NoteView(frame: NSRect(x:0, y:0, width: length, height: trackHeight))
+            let view = NoteView(frame: NSRect(x: 0, y: 0, width: length, height: trackHeight))
             view.addViewModel(viewModel)
             populateViewNotes(view, context: context, noteMap: noteMap)
             return view
@@ -56,7 +56,7 @@ struct NotesModel: ViewRepresentable {
             return view
         }
     }
-    
+
     func updateNSView(_ nsView: NSViewType, context: Context) {
         if let fileURL = fileURL {
             let noteMap = MIDIFileTrackNoteMap(midiFile: MIDIFile(url: fileURL), trackNumber: trackNumber)
@@ -67,8 +67,7 @@ struct NotesModel: ViewRepresentable {
             nsView.frame.origin.x = 0
             populateViewNotes(nsView, context: context, noteMap: noteMap)
         } else {
-            if nsView.subviews.count > 0
-            {
+            if nsView.subviews.count > 0 {
                 nsView.subviews.forEach({ $0.removeFromSuperview()})
             }
             nsView.frame.size.width = 0

--- a/Sources/AudioKitUI/Controls/MIDITrackView.swift
+++ b/Sources/AudioKitUI/Controls/MIDITrackView.swift
@@ -12,12 +12,12 @@ import Foundation
 class NoteView: NSView {
     var viewModel: MIDITrackViewModel?
     var cancellable = Set<AnyCancellable>()
-    
-    func addViewModel( _ wm: MIDITrackViewModel) {
-        self.viewModel = wm
+
+    func addViewModel( _ withModel: MIDITrackViewModel) {
+        self.viewModel = withModel
         self.viewModel?.$trackPosition
-            .sink(receiveValue: { [unowned self] w in
-                self.frame.origin.x = w
+            .sink(receiveValue: { [unowned self] pixelValue in
+                self.frame.origin.x = pixelValue
             }).store(in: &cancellable)
     }
 }
@@ -25,12 +25,12 @@ class NoteView: NSView {
 class NoteView: UIView {
     var viewModel: MIDITrackViewModel?
     var cancellable = Set<AnyCancellable>()
-    
-    func addViewModel( _ wm: MIDITrackViewModel) {
-        self.viewModel = wm
+
+    func addViewModel( _ withModel: MIDITrackViewModel) {
+        self.viewModel = withModel
         self.viewModel?.$trackPosition
-            .sink(receiveValue: { [unowned self] w in
-                self.frame.origin.x = w
+            .sink(receiveValue: { [unowned self] pixelValue in
+                self.frame.origin.x = pixelValue
             }).store(in: &cancellable)
     }
 }
@@ -78,7 +78,7 @@ struct NotesModel: ViewRepresentable {
             viewModel.trackPosition = 0
         }
     }
-    
+
     func populateViewNotes(_ nsView: NSView, context: Context, noteMap: MIDIFileTrackNoteMap) {
         let noteList = noteMap.noteList
         let low = noteMap.loNote
@@ -114,7 +114,7 @@ struct NotesModel: ViewRepresentable {
             return view
         }
     }
-    
+
     func updateUIView(_ uiView: UIViewType, context: Context) {
         if let fileURL = fileURL {
             let noteMap = MIDIFileTrackNoteMap(midiFile: MIDIFile(url: fileURL), trackNumber: trackNumber)
@@ -125,8 +125,7 @@ struct NotesModel: ViewRepresentable {
             uiView.frame.origin.x = 0
             populateViewNotes(uiView, context: context, noteMap: noteMap)
         } else {
-            if uiView.subviews.count > 0
-            {
+            if uiView.subviews.count > 0 {
                 uiView.subviews.forEach({ $0.removeFromSuperview()})
             }
             uiView.frame.size.width = 0
@@ -136,7 +135,7 @@ struct NotesModel: ViewRepresentable {
             viewModel.trackPosition = 0
         }
     }
-    
+
     func populateViewNotes(_ uiView: UIView, context: Context, noteMap: MIDIFileTrackNoteMap) {
         let noteList = noteMap.noteList
         let low = noteMap.loNote
@@ -171,7 +170,7 @@ public class MIDITrackViewModel: ObservableObject {
     public init() {
         engine.output = Reverb(sampler, dryWetMix: 0.2)
     }
-    
+
     public func startEngine() {
         do {
             try engine.start()
@@ -187,7 +186,9 @@ public class MIDITrackViewModel: ObservableObject {
         let inverse: Double = 1.0 / base
         let multiplier: Double = inverse * 60 * (10_000 / Double(50_000.0))
         sequencer.play()
-        trackTimer = Timer.scheduledTimer(timeInterval: multiplier * (1/lastTempo), target: self, selector: #selector(self.update), userInfo: nil, repeats: true)
+        trackTimer = Timer.scheduledTimer(timeInterval: multiplier * (1/lastTempo),
+                                          target: self, selector: #selector(self.update),
+                                          userInfo: nil, repeats: true)
         RunLoop.main.add(trackTimer, forMode: .common)
     }
 

--- a/Sources/AudioKitUI/Controls/MIDITrackView.swift
+++ b/Sources/AudioKitUI/Controls/MIDITrackView.swift
@@ -94,7 +94,7 @@ struct NotesModel: ViewRepresentable {
             let noteLevel = (maxh - (CGFloat(noteNumber) * noteh))
             let singleNoteRect = CGRect(x: notePosition, y: noteLevel, width: noteLength, height: noteh)
             let singleNoteView = NSView(frame: singleNoteRect)
-            singleNoteView.layer?.backgroundColor = noteColor.cgColor
+            singleNoteView.layer?.backgroundColor = CGColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)
             singleNoteView.layer?.cornerRadius = noteh * 0.5
             nsView.addSubview(singleNoteView)
         }

--- a/Sources/AudioKitUI/Controls/MIDITrackView.swift
+++ b/Sources/AudioKitUI/Controls/MIDITrackView.swift
@@ -94,7 +94,7 @@ struct NotesModel: ViewRepresentable {
             let noteLevel = (maxh - (CGFloat(noteNumber) * noteh))
             let singleNoteRect = CGRect(x: notePosition, y: noteLevel, width: noteLength, height: noteh)
             let singleNoteView = NSView(frame: singleNoteRect)
-            singleNoteView.layer?.backgroundColor = CGColor(red: 0.0, green: 1.0, blue: 0.0, alpha: 1.0)
+            singleNoteView.layer?.backgroundColor = noteColor.cgColor
             singleNoteView.layer?.cornerRadius = noteh * 0.5
             nsView.addSubview(singleNoteView)
         }


### PR DESCRIPTION
Addresses the topic of #46
1. Create `MIDITrackViewModel` - responsible for the sequencer and playing the track, created once and injected into the View's environment
2. Create `NotesModel` - populated with a `noteMap`
3. Create `NoteView` - behaves like the old `UIView` for the notes
4. Start migrating things to be SwiftUI friendly. Would like to avoid UIKit if at all possible