### PR TITLE
Added color argument to AudioFileWaveform View

### DIFF
--- a/Sources/AudioKitUI/Visualizations/AudioFileWaveform.swift
+++ b/Sources/AudioKitUI/Visualizations/AudioFileWaveform.swift
@@ -1,8 +1,8 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
 
-import SwiftUI
-import AudioKit
 import Accelerate
+import AudioKit
+import SwiftUI
 
 class AudioFileWaveformViewModel: ObservableObject {
     @Published var rmsValues = [Float]()
@@ -18,19 +18,21 @@ class AudioFileWaveformViewModel: ObservableObject {
 
 public struct AudioFileWaveform: View {
     @ObservedObject var viewModel: AudioFileWaveformViewModel
+    let color: Color
 
-    public init(url: URL, rmsSamplesPerWindow: Int = 256) {
+    public init(url: URL, rmsSamplesPerWindow: Int = 256, color: Color = Color.gray) {
         viewModel = AudioFileWaveformViewModel(url: url,
                                                rmsSamplesPerWindow: rmsSamplesPerWindow)
+        self.color = color
     }
 
     public var body: some View {
         if viewModel.rmsValues.count > 2 {
             AudioWaveform(rmsVals: viewModel.rmsValues)
-                .fill(Color.gray)
+                .fill(color)
         } else {
             AudioWaveform(rmsVals: viewModel.rmsValues)
-                .stroke(Color.gray)
+                .stroke(color)
         }
     }
 }

--- a/Sources/AudioKitUI/Visualizations/AudioFileWaveform.swift
+++ b/Sources/AudioKitUI/Visualizations/AudioFileWaveform.swift
@@ -40,6 +40,7 @@ public struct AudioFileWaveform: View {
 struct AudioFileWaveform_Previews: PreviewProvider {
     static var previews: some View {
         AudioFileWaveform(url: TestAudioURLs.drumloop.url())
+        AudioFileWaveform(url: TestAudioURLs.drumloop.url(), color: .red)
         AudioFileWaveform(url: TestAudioURLs.short.url(), rmsSamplesPerWindow: 1)
         AudioFileWaveform(url: TestAudioURLs.short.url())
     }


### PR DESCRIPTION
Simply added a color argument to the AudioFileWaveform View

`AudioFileWaveform(url: TestAudioURLs.drumloop.url(), color: .red)`

<img width="635" alt="Screen Shot 2022-05-31 at 11 23 05 AM" src="https://user-images.githubusercontent.com/15333030/171224327-43b4e10f-6cf0-4af7-967d-5e110b54c0ad.png">

