### PR TITLE
Fix link to AudioKitUI section on audiokit.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Waveform plots and controls that can be used to jump start your AudioKit-powered
 
 ## Documentation
 
-* [AudioKit.io Section about AudioKitUI](https://audiokit.io/Packages/AudioKitUI)
+* [AudioKit.io Section about AudioKitUI](https://audiokit.io/documentation/audiokit/audiokitui)
 * [API Reference Docs](https://github.com/AudioKit/AudioKitUI/wiki)
 
 ## Requirements


### PR DESCRIPTION
Currently, the link in the README goes to a dead page.