### PR TITLE
Add public on some visualizations views

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FloatPlot.swift
+++ b/Sources/AudioKitUI/Visualizations/FloatPlot.swift
@@ -41,7 +41,7 @@ public class FloatPlot: MTKView, MTKViewDelegate {
     texture1d<float, access::sample> waveform, device float* parameters, device float4* colorParameters) {
     """
 
-    init(frame frameRect: CGRect, fragment: String? = nil, dataCallback: @escaping () -> [Float]) {
+    public init(frame frameRect: CGRect, fragment: String? = nil, dataCallback: @escaping () -> [Float]) {
         self.dataCallback = dataCallback
         bufferSampleCount = Int(frameRect.width)
 

--- a/Sources/AudioKitUI/Visualizations/FragmentBuilder.swift
+++ b/Sources/AudioKitUI/Visualizations/FragmentBuilder.swift
@@ -23,11 +23,11 @@ public class FragmentBuilder {
     var isFilled: Bool = true
     var isFFT: Bool = false
 
-    init(foregroundColor: CGColor = Color.white.cg,
-         backgroundColor: CGColor = Color.clear.cg,
-         isCentered: Bool = true,
-         isFilled: Bool = true,
-         isFFT: Bool = false)
+    public init(foregroundColor: CGColor = Color.white.cg,
+                backgroundColor: CGColor = Color.clear.cg,
+                isCentered: Bool = true,
+                isFilled: Bool = true,
+                isFFT: Bool = false)
     {
         self.foregroundColor = foregroundColor
         self.backgroundColor = backgroundColor
@@ -36,7 +36,7 @@ public class FragmentBuilder {
         self.isFFT = isFFT
     }
 
-    var stringValue: String {
+    public var stringValue: String {
         return """
         float sample = waveform.sample(s, \(isFFT ? "(pow(10, in.t.x) - 1.0) / 9.0" : "in.t.x")).x;
 

--- a/Sources/AudioKitUI/Visualizations/SpectrogramView.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramView.swift
@@ -168,12 +168,28 @@ public struct SpectrogramView: View {
     @StateObject var spectrogram = SpectrogramModel()
     var node: Node
 
-    var linearGradient = LinearGradient(gradient: Gradient(colors: [.blue, .green, .yellow, .red]), startPoint: .bottom, endPoint: .top)
-    @State var strokeColor = Color.white.opacity(0.8)
-    @State var fillColor = Color.green.opacity(1.0)
-    @State var bottomColor = Color.white.opacity(0.5)
-    @State var sideColor = Color.white.opacity(0.2)
-    @State var backgroundColor = Color.black
+    var linearGradient: LinearGradient
+    @Binding var strokeColor: Color
+    @Binding var fillColor: Color
+    @Binding var bottomColor: Color
+    @Binding var sideColor: Color
+    @Binding var backgroundColor: Color
+
+    public init(node: Node,
+                linearGradient: LinearGradient = LinearGradient(gradient: Gradient(colors: [.blue, .green, .yellow, .red]), startPoint: .bottom, endPoint: .top),
+                strokeColor: Binding<Color> = .constant(Color.white.opacity(0.8)),
+                fillColor: Binding<Color> = .constant(Color.green.opacity(1.0)),
+                bottomColor: Binding<Color> = .constant(Color.white.opacity(0.5)),
+                sideColor: Binding<Color> = .constant(Color.white.opacity(0.2)),
+                backgroundColor: Binding<Color> = .constant(Color.black)) {
+        self.node = node
+        self.linearGradient = linearGradient
+        _strokeColor = strokeColor
+        _fillColor = fillColor
+        _bottomColor = bottomColor
+        _sideColor = sideColor
+        _backgroundColor = backgroundColor
+    }
 
     public var body: some View {
         let xOffset = CGFloat(0.22) / CGFloat(spectrogram.fftDataReadings.maxItems)


### PR DESCRIPTION
Motivation:

I'm working on some recording visualizations and discovered:
- `SpectrogramView` initializer was not public
- `NodeRollingView` could benefit from more control on configuration for reuse.
- Opened `FloatPlot` and `FragmentBuilder` so that people could their own components based on those two