### PR TITLE
Bumped CI to Swift 5.7, removed 5.5 and 5.6

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       scheme: AudioKitUI
       platforms: iOS macOS
-      swift-versions: 5.5 5.6
+      swift-versions: 5.7
 
   # Send notification to Discord on failure.
   send_notification:


### PR DESCRIPTION
AudioKit no longer builds for Swift 5.5 and 5.6, so any CI workflows that are relying on AudioKit and trying to build on 5.5 and 5.6 will fail.

This has to be updated to Swift 5.7 to work. Though it might be beneficial to figure out why AudioKit can't build for 5.5 and 5.6 -- those are both within the last year of Xcode releases, so worth supporting, but if the instructions are typically just to use an older version that makes sense, too.

## AudioKit
### https://swiftpackageindex.com/AudioKit/AudioKit
<img width="622" alt="image" src="https://user-images.githubusercontent.com/3022693/223194188-b82b4d86-ee62-4d02-b763-f03d31b51f65.png">

## AudioKitUI
### https://swiftpackageindex.com/AudioKit/AudioKitUI
<img width="617" alt="image" src="https://user-images.githubusercontent.com/3022693/223194232-998af9b5-db22-4376-a978-d6878fae1e54.png">
