### PR TITLE
silenced warning ...

### DIFF
--- a/Sources/AudioKitUI/Controls/TapCountingDrumPadGrid.swift
+++ b/Sources/AudioKitUI/Controls/TapCountingDrumPadGrid.swift
@@ -63,7 +63,7 @@ public struct TapCountingDrumPadGrid: View {
             let padHeight = gp.size.height / CGFloat(rows)
             let columns = Array(repeating: GridItem(.fixed(padWidth)), count: cols)
             LazyVGrid(columns: columns, spacing: 10) {
-                ForEach(0..<count) { idx in
+                ForEach(0..<count, id: \.self) { idx in
                     ZStack {
                         if #available(iOS 15.0, *) {
                             RoundedRectangle(cornerRadius: padWidth / 10)


### PR DESCRIPTION
... and fixed the risk of a crash once the `var rows` and `var cols` are really used in a dynamic fashion as the `ForEach` loop would not get updated