### PR TITLE
Update FFTView.swift

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FFTView.swift
+++ b/Sources/AudioKitUI/Visualizations/FFTView.swift
@@ -139,7 +139,8 @@ public struct FFTView: View {
                         AmplitudeBar(amplitude: amplitude,
                                      linearGradient: linearGradient,
                                      paddingFraction: paddingFraction,
-                                     includeCaps: includeCaps)
+                                     includeCaps: includeCaps,
+                                     backgroundColor: backgroundColor)
                     }
                 } else {
                     AmplitudeBar(amplitude: 0.0,


### PR DESCRIPTION
Fix bar mask color not matching background color in FFTView. Mentioned in #78