### PR TITLE
Fixed error on compilation of SpectrogramFlatView/UIColor+intermediate.swift for macOS 

### DIFF
--- a/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramFlatView.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramFlatView.swift
@@ -35,6 +35,19 @@ Steps involved:
    this implementation caches the resulting image.
  
  
+ Suggested next steps on development:
+ * Layout and draw the slices directly on a Canvas (instead of HStack) and independently move the Canvas left.
+ * Make class compatible with macOS 
+    - Drawing with Canvas instead of UIGraphicsImageRenderer 
+      (caching of UIImage no longer needed if callback can draw directly on one Canvas)
+    - CrossPlatformColor from Waveform.swift or Color.Resolved instead of UIColor for gradient lookup
+ * Add some parameters that can be changed while the spectrogram is running
+    - Pause so user can have a close look at the analyzed past
+    - Gain or sensitivity
+    - Speed of the rolling plot / detail frequency by adjusting fftSize
+    - Min and max frequency shown
+ 
+ 
  Cause of inefficiency of this implementation
  * Each time a new slice arrives from FFTTap, the view gets a complete layout update.
  * Rendering of new slices is done on a background thread and involves too many steps

--- a/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramFlatView.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramFlatView.swift
@@ -66,6 +66,8 @@ Steps involved:
 import AudioKit
 import SwiftUI
 
+#if !os(macOS) || targetEnvironment(macCatalyst)
+
 /// Displays a rolling plot of the frequency spectrum. 
 ///
 /// Each slice represents a point in time with the frequencies shown from bottom to top
@@ -145,3 +147,5 @@ struct SpectrogramFlatView_Previews: PreviewProvider {
         return SpectrogramFlatView(node: Mixer())
     }
 }
+
+#endif

--- a/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramModel.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramModel.swift
@@ -1,6 +1,8 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
 //
 
+#if !os(macOS) || targetEnvironment(macCatalyst)
+
 import AudioKit
 import SwiftUI
 
@@ -168,3 +170,5 @@ class SpectrogramFlatModel: ObservableObject {
     }
 
 }
+
+#endif

--- a/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramSlice.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/SpectrogramSlice.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
 
+#if !os(macOS) || targetEnvironment(macCatalyst)
+
 import SwiftUI
 
 /// One slice with frequencies from low frequencies at the bottom up to high frequences. 
@@ -286,3 +288,5 @@ struct SpectrogramSlice_Previews: PreviewProvider {
         ).scaleEffect(x: 1, y: -1)
     }
 }
+
+#endif

--- a/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/UIColor+intermediate.swift
+++ b/Sources/AudioKitUI/Visualizations/SpectrogramFlatView/UIColor+intermediate.swift
@@ -1,5 +1,7 @@
 // Copyright AudioKit. All Rights Reserved. Revision History at http://github.com/AudioKit/AudioKitUI/
 
+#if !os(macOS) || targetEnvironment(macCatalyst)
+
 import Foundation
 import UIKit
 
@@ -38,3 +40,5 @@ extension Array where Element: UIColor {
         }
     }
 }
+
+#endif


### PR DESCRIPTION
See Issue https://github.com/AudioKit/AudioKitUI/issues/83 where the log files shows how the compiler stumbled upon UIColor when compiling for macOS