### PR TITLE
Made FloatPlotCoordinator's view not opaque for non-visionOS devices.

### DIFF
--- a/Sources/AudioKitUI/Visualizations/FloatPlot.swift
+++ b/Sources/AudioKitUI/Visualizations/FloatPlot.swift
@@ -187,6 +187,8 @@ public class FloatPlotCoordinator {
 
     var view: MTKView {
         let view = MTKView(frame: CGRect(x: 0, y: 0, width: 1024, height: 1024), device: renderer.device)
+        view.layer.isOpaque = false
+        view.isOpaque = false
         view.clearColor = .init(red: 0.0, green: 0.0, blue: 0.0, alpha: 0)
         view.delegate = renderer
         return view


### PR DESCRIPTION
This allows for transparent backgrounds on NodeOutputViews and NodeRollingViews.

Would close #42.